### PR TITLE
Improved Pages Routes Resolution

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -29,6 +29,7 @@
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",
             "assets": [
+              "src/404.html",
               "src/favicon.png",
               "src/robots.txt",
               "src/assets",

--- a/routes.txt
+++ b/routes.txt
@@ -10,3 +10,7 @@
 /news
 /playground
 /contributors
+/settings
+/privacy
+/cookies
+/404

--- a/scripts/routes/generate.py
+++ b/scripts/routes/generate.py
@@ -62,6 +62,15 @@ def fetch_news_routes(base_url: str):
     return routes
 
 
+def fetch_contributor_routes(base_url: str):
+    routes = []
+
+    for item in load_all_feed_items(base_url, 'contributors'):
+        routes.append(f'/contributors/{item["_username"]}')
+
+    return routes
+
+
 def fetch_academy_routes(base_url: str):
     routes = []
 
@@ -81,7 +90,7 @@ def fetch_academy_routes(base_url: str):
 
 
 def generate(base_url: str):
-    routes = fetch_academy_routes(base_url) + fetch_news_routes(base_url)
+    routes = fetch_academy_routes(base_url) + fetch_news_routes(base_url) + fetch_contributor_routes(base_url)
     return '\n'.join(routes)
 
 

--- a/src/404.html
+++ b/src/404.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>SYCL.tech - 404</title>
+  <meta http-equiv="refresh" content="0; url=/404">
+  <script type="text/javascript">window.location.href = "/404"</script>
+  <link rel="icon" type="image/png" href="favicon.png"/>
+</head>
+<body></body>
+</html>

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -35,6 +35,7 @@ import { PlaygroundComponent } from './pages/playground/playground.component';
 import { CookiesComponent } from './pages/cookies/cookies.component';
 import { PrivacyComponent } from './pages/privacy/privacy.component';
 import { SettingsComponent } from './pages/settings/settings.component';
+import { Error404Component } from './pages/404/error-404.component';
 
 export const routes: Routes = [
   {
@@ -114,4 +115,13 @@ export const routes: Routes = [
     path: 'contributors/:username',
     component: ContributorComponent
   },
+  {
+    path: '404',
+    component: Error404Component,
+    pathMatch: 'full'
+  },
+  {
+    path: '**',
+    redirectTo: '404'
+  }
 ];

--- a/src/app/pages/404/error-404.component.html
+++ b/src/app/pages/404/error-404.component.html
@@ -1,0 +1,14 @@
+<section id="intro">
+  <div class="wrapper panel fancy intro">
+    <div>
+      <header>
+        <h1>404 - Page Not Found</h1>
+        <h2>This page seems to have gone missing. We're sorry about that! Please check back soon if you think this
+        should be here or report it to us.</h2>
+      </header>
+    </div>
+    <div>
+      <span class="material-symbols-outlined panel-icon">search_off</span>
+    </div>
+  </div>
+</section>

--- a/src/app/pages/404/error-404.component.ts
+++ b/src/app/pages/404/error-404.component.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *--------------------------------------------------------------------------------------------*/
+
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'st-error-404',
+  standalone: true,
+  imports: [
+    CommonModule
+  ],
+  templateUrl: './error-404.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class Error404Component {
+
+}


### PR DESCRIPTION
This PR fixes an issue where GitHub pages looks for a 404.html file at the top level of the site directory. Due to how Angular works, this would not be present. This PR adds a static html that redirects to the correct error page.

This PR also adds some missing route generations.