### PR TITLE
Small Temporary Node FIx

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Node.js 22
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
         with:
-          node-version: 22
+          node-version: 22.4.1
           cache: 'npm'
       - name: Install Dependencies
         run: npm ci

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,6 @@ on:
     branches: [ 'main' ]
   pull_request:
     branches: [ 'main' ]
-  schedule:
-    - cron: '0 0 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,8 @@ on:
     branches: [ 'main' ]
   pull_request:
     branches: [ 'main' ]
+  schedule:
+    - cron: '31 11 * * 2'
 
 permissions: read-all
 


### PR DESCRIPTION
This fixes a build issue relating to Node 22.5.0 returning the error code:

```
npm error Exit handler never called!
npm error This is an error with npm itself. Please report this error at:
```

This PR sets the version to 22.4.1 which is confirmed working.